### PR TITLE
Remove wifiSsid and wifiKey options

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -75,8 +75,6 @@ exports.get = function(uuid, options) {
         deviceType: device.device_type,
         userId: String(userId),
         username: username,
-        wifiSsid: options.wifiSsid,
-        wifiKey: options.wifiKey,
         files: network.getFiles(options),
         registered_at: Math.floor(Date.now() / 1000),
         appUpdatePollInterval: '60000',

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -72,8 +72,6 @@ exports.get = (uuid, options = {}) ->
 				deviceType: device.device_type
 				userId: String(userId)
 				username: username
-				wifiSsid: options.wifiSsid
-				wifiKey: options.wifiKey
 				files: network.getFiles(options)
 				registered_at: Math.floor(Date.now() / 1000)
 				appUpdatePollInterval: '60000'

--- a/tests/config.spec.coffee
+++ b/tests/config.spec.coffee
@@ -96,8 +96,6 @@ describe 'Device Config:', ->
 								userId: '13'
 								registered_at: 15000
 								username: 'johndoe'
-								wifiSsid: undefined
-								wifiKey: undefined
 								appUpdatePollInterval: '60000'
 								files:
 									'network/settings': '''
@@ -139,8 +137,6 @@ describe 'Device Config:', ->
 								userId: '13'
 								registered_at: 15000
 								username: 'johndoe'
-								wifiSsid: 'foo'
-								wifiKey: 'bar'
 								appUpdatePollInterval: '60000'
 								files:
 									'network/settings': '''


### PR DESCRIPTION
These options were deprecated in favour of `files`.
