### PR TITLE
Upgrade resin-settings-client to v3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^3.10.0",
     "resin-errors": "^1.0.2",
     "resin-sdk": "^3.0.0",
-    "resin-settings-client": "^3.2.1",
+    "resin-settings-client": "^3.2.2",
     "revalidator": "^0.3.1"
   }
 }


### PR DESCRIPTION
This version contains a fix to default user home directory to temporary
directory.
