### PR TITLE
Throw an error if vpnPort is NaN

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -77,6 +77,9 @@ exports.generate = function(options, params) {
   if (params == null) {
     params = {};
   }
+  _.defaults(options, {
+    vpnPort: 1723
+  });
   config = {
     applicationName: options.application.app_name,
     applicationId: options.application.id,
@@ -86,7 +89,7 @@ exports.generate = function(options, params) {
     files: network.getFiles(params),
     appUpdatePollInterval: params.appUpdatePollInterval || 60000,
     listenPort: 48484,
-    vpnPort: _.parseInt(options.vpnPort) || 1723,
+    vpnPort: options.vpnPort,
     apiEndpoint: options.endpoints.api,
     vpnEndpoint: options.endpoints.vpn,
     registryEndpoint: options.endpoints.registry,
@@ -142,7 +145,9 @@ exports.generate = function(options, params) {
 
 exports.validate = function(config) {
   var disallowedProperty, error, validation;
-  validation = revalidator.validate(config, schema);
+  validation = revalidator.validate(config, schema, {
+    cast: true
+  });
   if (!validation.valid) {
     error = _.first(validation.errors);
     throw new Error("Validation: " + error.property + " " + error.message);

--- a/build/schema.js
+++ b/build/schema.js
@@ -14,6 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+var _;
+
+_ = require('lodash');
+
 
 /**
  * @summary config.json validation schema
@@ -25,6 +29,7 @@ limitations under the License.
  *
  *		https://github.com/flatiron/revalidator
  */
+
 module.exports = {
   properties: {
     applicationName: {
@@ -92,7 +97,11 @@ module.exports = {
       description: 'vpn port',
       type: 'number',
       minimum: 0,
-      required: true
+      required: true,
+      conform: _.negate(_.isNaN),
+      messages: {
+        conform: 'is NaN'
+      }
     },
     apiEndpoint: {
       description: 'api endpoint',

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -63,6 +63,10 @@ schema = require('./schema')
 # console.log(config)
 ###
 exports.generate = (options, params = {}) ->
+
+	_.defaults options,
+		vpnPort: 1723
+
 	config =
 		applicationName: options.application.app_name
 		applicationId: options.application.id
@@ -74,7 +78,7 @@ exports.generate = (options, params = {}) ->
 		appUpdatePollInterval: params.appUpdatePollInterval or 60000
 
 		listenPort: 48484
-		vpnPort: _.parseInt(options.vpnPort) or 1723
+		vpnPort: options.vpnPort
 
 		apiEndpoint: options.endpoints.api
 		vpnEndpoint: options.endpoints.vpn
@@ -128,7 +132,7 @@ exports.generate = (options, params = {}) ->
 # deviceConfig.validate(config)
 ###
 exports.validate = (config) ->
-	validation = revalidator.validate(config, schema)
+	validation = revalidator.validate(config, schema, cast: true)
 
 	if not validation.valid
 		error = _.first(validation.errors)

--- a/lib/schema.coffee
+++ b/lib/schema.coffee
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ###
 
+_ = require('lodash')
+
 ###*
 # @summary config.json validation schema
 # @name schema
@@ -81,6 +83,9 @@ module.exports =
 			type: 'number'
 			minimum: 0
 			required: true
+			conform: _.negate(_.isNaN)
+			messages:
+				conform: 'is NaN'
 		apiEndpoint:
 			description: 'api endpoint'
 			type: 'string'

--- a/tests/config.spec.coffee
+++ b/tests/config.spec.coffee
@@ -172,33 +172,61 @@ describe 'Device Config:', ->
 
 			m.chai.expect(config.vpnPort).to.equal(1234)
 
-		it 'should handle a NaN vpnPort', ->
-			config = deviceConfig.generate
-				application:
-					app_name: 'HelloWorldApp'
-					id: 18
-					device_type: 'raspberry-pi'
-				user:
-					id: 7
-					username: 'johndoe'
-				pubnub:
-					subscribe_key: 'demo'
-					publish_key: 'demo'
-				mixpanel:
-					token: 'e3bc4100330c35722740fb8c6f5abddc'
-				apiKey: 'asdf'
-				vpnPort: 'hello'
-				endpoints:
-					api: 'https://api.resin.io'
-					vpn: 'vpn.resin.io'
-					registry: 'registry.resin.io'
-					delta: 'https://delta.resin.io'
-			,
-				network: 'wifi'
-				wifiSsid: 'mywifi'
-				wifiKey: 'secret'
+		it 'should throw an error if vpnPort becomes NaN', ->
+			m.chai.expect ->
+				config = deviceConfig.generate
+					application:
+						app_name: 'HelloWorldApp'
+						id: 18
+						device_type: 'raspberry-pi'
+					user:
+						id: 7
+						username: 'johndoe'
+					pubnub:
+						subscribe_key: 'demo'
+						publish_key: 'demo'
+					mixpanel:
+						token: 'e3bc4100330c35722740fb8c6f5abddc'
+					apiKey: 'asdf'
+					vpnPort: 'hello'
+					endpoints:
+						api: 'https://api.resin.io'
+						vpn: 'vpn.resin.io'
+						registry: 'registry.resin.io'
+						delta: 'https://delta.resin.io'
+				,
+					network: 'wifi'
+					wifiSsid: 'mywifi'
+					wifiKey: 'secret'
+			.to.throw('Validation: vpnPort must be of number type')
 
-			m.chai.expect(config.vpnPort).to.equal(1723)
+		it 'should throw an error if vpnPort is NaN', ->
+			m.chai.expect ->
+				config = deviceConfig.generate
+					application:
+						app_name: 'HelloWorldApp'
+						id: 18
+						device_type: 'raspberry-pi'
+					user:
+						id: 7
+						username: 'johndoe'
+					pubnub:
+						subscribe_key: 'demo'
+						publish_key: 'demo'
+					mixpanel:
+						token: 'e3bc4100330c35722740fb8c6f5abddc'
+					apiKey: 'asdf'
+					vpnPort: NaN
+					endpoints:
+						api: 'https://api.resin.io'
+						vpn: 'vpn.resin.io'
+						registry: 'registry.resin.io'
+						delta: 'https://delta.resin.io'
+				,
+					network: 'wifi'
+					wifiSsid: 'mywifi'
+					wifiKey: 'secret'
+			.to.throw('Validation: vpnPort is NaN')
 
 		it 'should allow deltaEndpoint to be undefined', ->
 			config = null
@@ -217,7 +245,7 @@ describe 'Device Config:', ->
 					mixpanel:
 						token: 'e3bc4100330c35722740fb8c6f5abddc'
 					apiKey: 'asdf'
-					vpnPort: 'hello'
+					vpnPort: '1234'
 					endpoints:
 						api: 'https://api.resin.io'
 						vpn: 'vpn.resin.io'


### PR DESCRIPTION
We currently apply the default vpn port number if this is the case,
which might be confusing.

See https://github.com/resin-io/resin-device-config/pull/26#discussion_r52496039
