### PR TITLE
Add basic support for static ips

### DIFF
--- a/build/settings.js
+++ b/build/settings.js
@@ -37,6 +37,10 @@ exports.main = '[global]\nOfflineMode=false\n\n[WiFi]\nEnable=true\nTethering=fa
  * @param {Object} options - options
  * @param {String} [options.wifiSsid] - wifi ssid
  * @param {String} [options.wifiKey] - wifi key
+ * @param {Boolean} [options.staticIp] - whether to use a static ip
+ * @param {String} [options.ip] - static ip address
+ * @param {String} [options.netmask] - static ip netmask
+ * @param {String} [options.gateway] - static ip gateway
  *
  * @returns {String} Network configuration.
  *
@@ -47,14 +51,27 @@ exports.main = '[global]\nOfflineMode=false\n\n[WiFi]\nEnable=true\nTethering=fa
  */
 
 exports.getHomeSettings = function(options) {
-  var config, _ref;
+  var config, staticIpConfiguration, _ref;
+  _.defaults(options, {
+    netmask: '255.255.255.0'
+  });
   config = '[service_home_ethernet]\nType = ethernet\nNameservers = 8.8.8.8,8.8.4.4';
+  if (options.ip != null) {
+    if (options.gateway == null) {
+      throw new Error('Missing network gateway');
+    }
+    staticIpConfiguration = "\nIPv4 = " + options.ip + "/" + options.netmask + "/" + options.gateway;
+    config += staticIpConfiguration;
+  }
   if (!_.isEmpty((_ref = options.wifiSsid) != null ? _ref.trim() : void 0)) {
     config += "\n\n[service_home_wifi]\nType = wifi\nName = " + options.wifiSsid;
     if (options.wifiKey) {
       config += "\nPassphrase = " + options.wifiKey;
     }
     config += '\nNameservers = 8.8.8.8,8.8.4.4';
+    if (staticIpConfiguration != null) {
+      config += staticIpConfiguration;
+    }
   }
   return config;
 };

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -47,6 +47,10 @@ exports.main = '''
 # @param {Object} options - options
 # @param {String} [options.wifiSsid] - wifi ssid
 # @param {String} [options.wifiKey] - wifi key
+# @param {Boolean} [options.staticIp] - whether to use a static ip
+# @param {String} [options.ip] - static ip address
+# @param {String} [options.netmask] - static ip netmask
+# @param {String} [options.gateway] - static ip gateway
 #
 # @returns {String} Network configuration.
 #
@@ -57,11 +61,22 @@ exports.main = '''
 ###
 exports.getHomeSettings = (options) ->
 
+	_.defaults options,
+		netmask: '255.255.255.0'
+
 	config = '''
 		[service_home_ethernet]
 		Type = ethernet
 		Nameservers = 8.8.8.8,8.8.4.4
 	'''
+
+	if options.ip?
+
+		if not options.gateway?
+			throw new Error('Missing network gateway')
+
+		staticIpConfiguration = "\nIPv4 = #{options.ip}/#{options.netmask}/#{options.gateway}"
+		config += staticIpConfiguration
 
 	if not _.isEmpty(options.wifiSsid?.trim())
 		config += """\n
@@ -74,5 +89,8 @@ exports.getHomeSettings = (options) ->
 			config += "\nPassphrase = #{options.wifiKey}"
 
 		config += '\nNameservers = 8.8.8.8,8.8.4.4'
+
+		if staticIpConfiguration?
+			config += staticIpConfiguration
 
 	return config

--- a/tests/network.spec.coffee
+++ b/tests/network.spec.coffee
@@ -42,6 +42,61 @@ describe 'Network:', ->
 						Nameservers = 8.8.8.8,8.8.4.4
 					'''
 
+		describe 'given static ips', ->
+
+			it 'should configure for ethernet', ->
+				files = network.getFiles
+					ip: '192.168.1.100'
+					netmask: '255.255.255.0'
+					gateway: '192.168.1.1'
+
+				m.chai.expect(files['network/network.config']).to.equal '''
+					[service_home_ethernet]
+					Type = ethernet
+					Nameservers = 8.8.8.8,8.8.4.4
+					IPv4 = 192.168.1.100/255.255.255.0/192.168.1.1
+				'''
+
+			it 'should apply a default netmask', ->
+				files = network.getFiles
+					ip: '192.168.1.100'
+					gateway: '192.168.1.1'
+
+				m.chai.expect(files['network/network.config']).to.equal '''
+					[service_home_ethernet]
+					Type = ethernet
+					Nameservers = 8.8.8.8,8.8.4.4
+					IPv4 = 192.168.1.100/255.255.255.0/192.168.1.1
+				'''
+
+			it 'should throw if no gateway', ->
+				m.chai.expect ->
+					network.getFiles
+						ip: '192.168.1.100'
+				.to.throw('Missing network gateway')
+
+			it 'should configure for both wifi and ethernet', ->
+				files = network.getFiles
+					wifiSsid: 'mynetwork'
+					wifiKey: 'secret'
+					ip: '192.168.1.100'
+					netmask: '255.255.255.0'
+					gateway: '192.168.1.1'
+
+				m.chai.expect(files['network/network.config']).to.equal '''
+					[service_home_ethernet]
+					Type = ethernet
+					Nameservers = 8.8.8.8,8.8.4.4
+					IPv4 = 192.168.1.100/255.255.255.0/192.168.1.1
+
+					[service_home_wifi]
+					Type = wifi
+					Name = mynetwork
+					Passphrase = secret
+					Nameservers = 8.8.8.8,8.8.4.4
+					IPv4 = 192.168.1.100/255.255.255.0/192.168.1.1
+				'''
+
 		describe 'given a wifi ssid but no key', ->
 
 			it 'should configure for wifi without a passphrase', ->


### PR DESCRIPTION
The connman configuration is modified as explained in the following blog
post: https://resin.io/blog/how-to-configure-a-static-ip-address-with-resin-io/

Support for this feature is said to be "basic" since it misses advanced
settings like configuring a static ip for ethernet but not for wifi, or
having different static ip settings for certain network configurations.
More advanced configuration support will come in the future, since
deciding on a data structure that supports such flexibility would
introduce breaking changes in various Resin.io components, and thus
needs discussion.

The way it works now, if the network is configured to `ethernet`, the
static ip is applied to the ethernet section, and if the network `wifi`,
we configure the static ip for _both wifi and ethernet_ sections.
