### PR TITLE
Disable connman ntp handling

### DIFF
--- a/build/settings.js
+++ b/build/settings.js
@@ -26,7 +26,7 @@ _ = require('lodash');
  * @type {String}
  */
 
-exports.main = '[global]\nOfflineMode=false\n\n[WiFi]\nEnable=true\nTethering=false\n\n[Wired]\nEnable=true\nTethering=false\n\n[Bluetooth]\nEnable=true\nTethering=false';
+exports.main = '[global]\nOfflineMode=false\nTimeUpdates=manual\n\n[WiFi]\nEnable=true\nTethering=false\n\n[Wired]\nEnable=true\nTethering=false\n\n[Bluetooth]\nEnable=true\nTethering=false';
 
 
 /**

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -25,6 +25,7 @@ _ = require('lodash')
 exports.main = '''
 	[global]
 	OfflineMode=false
+	TimeUpdates=manual
 
 	[WiFi]
 	Enable=true

--- a/tests/config.spec.coffee
+++ b/tests/config.spec.coffee
@@ -424,6 +424,7 @@ describe 'Device Config:', ->
 									'network/settings': '''
 										[global]
 										OfflineMode=false
+										TimeUpdates=manual
 
 										[WiFi]
 										Enable=true
@@ -472,6 +473,7 @@ describe 'Device Config:', ->
 									'network/settings': '''
 										[global]
 										OfflineMode=false
+										TimeUpdates=manual
 
 										[WiFi]
 										Enable=true
@@ -524,6 +526,7 @@ describe 'Device Config:', ->
 									'network/settings': '''
 										[global]
 										OfflineMode=false
+										TimeUpdates=manual
 
 										[WiFi]
 										Enable=true
@@ -607,6 +610,7 @@ describe 'Device Config:', ->
 							'network/settings': '''
 								[global]
 								OfflineMode=false
+								TimeUpdates=manual
 
 								[WiFi]
 								Enable=true
@@ -652,6 +656,7 @@ describe 'Device Config:', ->
 							'network/settings': '''
 								[global]
 								OfflineMode=false
+								TimeUpdates=manual
 
 								[WiFi]
 								Enable=true

--- a/tests/network.spec.coffee
+++ b/tests/network.spec.coffee
@@ -23,6 +23,7 @@ describe 'Network:', ->
 					'network/settings': '''
 						[global]
 						OfflineMode=false
+						TimeUpdates=manual
 
 						[WiFi]
 						Enable=true
@@ -106,6 +107,7 @@ describe 'Network:', ->
 					'network/settings': '''
 						[global]
 						OfflineMode=false
+						TimeUpdates=manual
 
 						[WiFi]
 						Enable=true
@@ -142,6 +144,7 @@ describe 'Network:', ->
 					'network/settings': '''
 						[global]
 						OfflineMode=false
+						TimeUpdates=manual
 
 						[WiFi]
 						Enable=true


### PR DESCRIPTION
We now rely on systemd-timesyncd for ntp

Signed-off-by: Florin Sarbu florin@resin.io
