### PR TITLE
Continue to include empty pubnub keys for backwards compatibility

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -102,6 +102,10 @@ exports.generate = (options, params = {}) ->
 		registryEndpoint: options.endpoints.registry
 		deltaEndpoint: options.endpoints.delta
 
+		# Included for backwards compatibility with older CLIs
+		pubnubSubscribeKey: ''
+		pubnubPublishKey: ''
+
 		mixpanelToken: options.mixpanel.token
 
 	if options.apiKey?

--- a/lib/schema.coffee
+++ b/lib/schema.coffee
@@ -110,6 +110,16 @@ module.exports =
 			required: true
 			allowEmpty: false
 			format: 'host-name'
+		pubnubSubscribeKey:
+			description: 'pubnub subscribe key'
+			type: 'string'
+			required: false
+			allowEmpty: true
+		pubnubPublishKey:
+			description: 'pubnub publish key'
+			type: 'string'
+			required: false
+			allowEmpty: true
 		mixpanelToken:
 			description: 'mixpanel token'
 			type: 'string'

--- a/tests/config.spec.coffee
+++ b/tests/config.spec.coffee
@@ -459,3 +459,47 @@ describe 'Device Config:', ->
 				wifiSsid: 'mywifi'
 				wifiKey: 'secret'
 			m.chai.expect(config.balenaRootCA).to.not.exist
+
+		it 'should allow config without pubnub keys', ->
+			config = {
+				applicationName: 'app',
+				applicationId: 123,
+				deviceType: 'devicetype',
+				userId: 123,
+				username: 'username',
+				appUpdatePollInterval: 60000,
+				listenPort: 48484,
+				vpnPort: 443,
+				apiEndpoint: 'https://api.com',
+				vpnEndpoint: 'https://vpn.com',
+				registryEndpoint: 'https://registry.com',
+				deltaEndpoint: undefined,
+				mixpanelToken: 'mixpanel'
+			}
+
+			m.chai.expect ->
+				deviceConfig.validate(config)
+			.to.not.throw(Error)
+
+		it 'should allow config with empty pubnub keys', ->
+			config = {
+				applicationName: 'app',
+				applicationId: 123,
+				deviceType: 'devicetype',
+				userId: 123,
+				username: 'username',
+				appUpdatePollInterval: 60000,
+				listenPort: 48484,
+				vpnPort: 443,
+				apiEndpoint: 'https://api.com',
+				vpnEndpoint: 'https://vpn.com',
+				registryEndpoint: 'https://registry.com',
+				deltaEndpoint: undefined,
+				pubnubSubscribeKey: '',
+				pubnubPublishKey: '',
+				mixpanelToken: 'mixpanel'
+			}
+
+			m.chai.expect ->
+				deviceConfig.validate(config)
+			.to.not.throw(Error)


### PR DESCRIPTION
This ensures that API generated config includes empty pubnub keys, so existing installs of v9 CLI versions will validate API-generated config successfully.

It also relaxes the schema further, so all new installs of those specific CLI versions (v9.0.0 & v9.0.1) will allow those fields to be totally removed in future.

Change-type: patch